### PR TITLE
Now works on puppet 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ spec/fixtures
 .yardoc
 _yardoc
 doc/
+/.tmp/classes.txt
+/.tmp/last_run_summary.yaml
+/.byebug_history
+/.tmp/resources.txt

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-version
+.ruby-gemset
+*/spec/fixtures
+spec/fixtures
 
 # YARD artifacts
 .yardoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,80 @@
+language: ruby
+
+cache: bundler
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  # - 2.2.0
+  # - jruby-19mode
+  # - rbx-19mode
+bundler_args: --without development
+
+# before_install:
+#   - rake spec_prep
+
+script:
+  - bundle exec rake spec
+# matrix:
+#   allow_failures:
+#     -rvm: jruby-19mode
+gemfile:
+  - gemfiles/gemfile.1.8.7
+  - gemfiles/gemfile.1.9.3
+  - gemfiles/gemfile.2.0.0
+
+env:
+  # - PUPPET_GEM_VERSION=3.0.2
+  # - PUPPET_GEM_VERSION=3.1.1
+  # - PUPPET_GEM_VERSION=3.2.4
+  # - PUPPET_GEM_VERSION=3.3.2
+  # - PUPPET_GEM_VERSION=3.4.3
+  - PUPPET_GEM_VERSION=3.7.3
+  - PUPPET_GEM_VERSION=3.7.4
+  - PUPPET_GEM_VERSION=3.7.5
+  - PUPPET_GEM_VERSION=3.8.3
+  - PUPPET_GEM_VERSION=4.0.0
+  - PUPPET_GEM_VERSION=4.1.0
+  - PUPPET_GEM_VERSION=4.2.3
+  - PUPPET_GEM_VERSION=4.3.2
+  - PUPPET_GEM_VERSION=4.4.2
+  - PUPPET_GEM_VERSION=4.5.3
+  - PUPPET_GEM_VERSION=4.6.1
+
+
+matrix:
+  exclude:
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.0.0
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.1.0
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.2.3
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.3.2
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.4.2
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.5.3
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=4.6.1
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION=4.6.1
+    - rvm: 1.8.7
+      gemfile: gemfiles/gemfile.1.9.3
+    - rvm: 1.8.7
+      gemfile: gemfiles/gemfile.2.0.0
+    - rvm: 1.9.3
+      gemfile: gemfiles/gemfile.1.8.7
+    - rvm: 1.9.3
+      gemfile: gemfiles/gemfile.2.0.0
+    - rvm: 2.0.0
+      gemfile: gemfiles/gemfile.1.8.7
+    - rvm: 2.0.0
+      gemfile: gemfiles/gemfile.1.9.3
+    - rvm: 2.1.0
+      gemfile: gemfiles/gemfile.1.8.7
+    - rvm: 2.1.0
+      gemfile: gemfiles/gemfile.1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,22 @@
+source "https://rubygems.org"
+
+group :development, :test do
+  gem 'rake'
+  gem 'rspec', "~> 3.1.0", :require => false
+  gem 'mocha', "~> 0.10.5", :require => false
+  gem 'puppetlabs_spec_helper', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+gem 'puppet-lint', '>= 1.0.0'
+gem 'puppet-lint-unquoted_string-check', :require => false
+
+if RUBY_VERSION < '2.0'
+      gem 'mime-types', '<3.0', :require => false
+end
+# vim:ft=ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    hiera (1.3.4)
+      json_pure
+    json_pure (1.8.3)
+    metaclass (0.0.4)
+    mocha (0.10.5)
+      metaclass (~> 0.0.1)
+    puppet (3.8.6)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-lint-unquoted_string-check (0.2.5)
+      puppet-lint (~> 1.0)
+    puppet-syntax (2.1.0)
+      rake
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (11.1.0)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-puppet (2.3.2)
+      rspec
+    rspec-support (3.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mocha (~> 0.10.5)
+  puppet
+  puppet-lint (>= 1.0.0)
+  puppet-lint-unquoted_string-check
+  puppetlabs_spec_helper
+  rake
+  rspec (~> 3.1.0)
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
+[![Build Status](https://travis-ci.org/hajee/puppet-refacter.svg?branch=master)](https://travis-ci.org/hajee/puppet-refacter)
 puppet-refacter
 ===============
 
-Puppet provider to refresh facter and automatically reload if specified facts changed
+Puppet type and provider to refresh facter and automatically reload if specified facts changed
 
 Sometimes applying resources while running puppet changes the system in such
 a way that you need to *re-run puppet* to pick up new facts and finish making
@@ -37,4 +38,3 @@ client-server mode, *patches welcome*.
 
 --
 Stephen R. Scaffidi | stephen@scaffidi.net | Just Another (Perl|Python|Puppet) Hacker
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.relative = true
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]

--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,4 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']

--- a/gemfiles/gemfile.1.8.7
+++ b/gemfiles/gemfile.1.8.7
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+gem 'rake', '~> 10.0.0', :require => false
+gem 'rspec-core', '3.1.7'
+gem 'puppetlabs_spec_helper', :require => false
+gem 'rspec-mocks'
+gem 'json', '1.8.3' # This is the last versions to support ruby pre 2.0 versions
+gem 'json_pure', '2.0.1' # This is the last versions to support ruby pre 2.0 versions
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end

--- a/gemfiles/gemfile.1.8.7.lock
+++ b/gemfiles/gemfile.1.8.7.lock
@@ -7,9 +7,10 @@ GEM
       CFPropertyList (~> 2.2.6)
     hiera (1.3.4)
       json_pure
-    json_pure (2.0.2)
+    json (1.8.3)
+    json_pure (2.0.1)
     metaclass (0.0.4)
-    mocha (0.10.5)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     puppet (3.6.2)
       facter (> 1.6, < 3)
@@ -19,13 +20,12 @@ GEM
     puppet-lint (2.0.2)
     puppet-syntax (2.1.0)
       rake
-    puppetlabs_spec_helper (1.1.1)
-      mocha
-      puppet-lint
-      puppet-syntax
-      rake
-      rspec-puppet
-    rake (11.2.2)
+    puppetlabs_spec_helper (1.2.1)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rake (10.0.4)
     rgen (0.6.6)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -46,10 +46,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json (= 1.8.3)
+  json_pure (= 2.0.1)
   puppet (= 3.6.2)
   puppetlabs_spec_helper
-  rake
-  rspec (~> 3.1.0)
+  rake (~> 10.0.0)
+  rspec-core (= 3.1.7)
+  rspec-mocks
 
 BUNDLED WITH
    1.12.5

--- a/gemfiles/gemfile.1.9.3
+++ b/gemfiles/gemfile.1.9.3
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+gem 'rake', '~> 10.0.0', :require => false
+gem 'rspec-core', '3.1.7'
+gem 'puppetlabs_spec_helper', :require => false
+gem 'rspec-mocks'
+gem 'json', '1.8.3' # This is the last versions to support ruby pre 2.0 versions
+gem 'json_pure', '2.0.1' # This is the last versions to support ruby pre 2.0 versions
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end

--- a/gemfiles/gemfile.1.9.3.lock
+++ b/gemfiles/gemfile.1.9.3.lock
@@ -7,9 +7,10 @@ GEM
       CFPropertyList (~> 2.2.6)
     hiera (1.3.4)
       json_pure
-    json_pure (2.0.2)
+    json (1.8.3)
+    json_pure (2.0.1)
     metaclass (0.0.4)
-    mocha (0.10.5)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     puppet (3.6.2)
       facter (> 1.6, < 3)
@@ -19,13 +20,12 @@ GEM
     puppet-lint (2.0.2)
     puppet-syntax (2.1.0)
       rake
-    puppetlabs_spec_helper (1.1.1)
-      mocha
-      puppet-lint
-      puppet-syntax
-      rake
-      rspec-puppet
-    rake (11.2.2)
+    puppetlabs_spec_helper (1.2.1)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rake (10.0.4)
     rgen (0.6.6)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -46,10 +46,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json (= 1.8.3)
+  json_pure (= 2.0.1)
   puppet (= 3.6.2)
   puppetlabs_spec_helper
-  rake
-  rspec (~> 3.1.0)
+  rake (~> 10.0.0)
+  rspec-core (= 3.1.7)
+  rspec-mocks
 
 BUNDLED WITH
    1.12.5

--- a/gemfiles/gemfile.2.0.0
+++ b/gemfiles/gemfile.2.0.0
@@ -1,11 +1,11 @@
-# rubocop: disable Style/HashSyntax
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'rspec', '~> 3.1.0', :require => false
+gem 'rake', '~> 10.0.0', :require => false
+gem 'rspec-core'
 gem 'puppetlabs_spec_helper', :require => false
+gem 'rspec-mocks'
 
-if (puppetversion = ENV['PUPPET_GEM_VERSION'])
+if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false

--- a/gemfiles/gemfile.2.0.0.lock
+++ b/gemfiles/gemfile.2.0.0.lock
@@ -9,7 +9,7 @@ GEM
       json_pure
     json_pure (2.0.2)
     metaclass (0.0.4)
-    mocha (0.10.5)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     puppet (3.6.2)
       facter (> 1.6, < 3)
@@ -19,28 +19,28 @@ GEM
     puppet-lint (2.0.2)
     puppet-syntax (2.1.0)
       rake
-    puppetlabs_spec_helper (1.1.1)
-      mocha
-      puppet-lint
-      puppet-syntax
-      rake
-      rspec-puppet
-    rake (11.2.2)
+    puppetlabs_spec_helper (1.2.1)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rake (10.0.4)
     rgen (0.6.6)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
     rspec-puppet (2.4.0)
       rspec
-    rspec-support (3.1.2)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -48,8 +48,9 @@ PLATFORMS
 DEPENDENCIES
   puppet (= 3.6.2)
   puppetlabs_spec_helper
-  rake
-  rspec (~> 3.1.0)
+  rake (~> 10.0.0)
+  rspec-core
+  rspec-mocks
 
 BUNDLED WITH
    1.12.5

--- a/lib/puppet/provider/refacter/ruby.rb
+++ b/lib/puppet/provider/refacter/ruby.rb
@@ -10,6 +10,13 @@ END
     require 'set'
     require 'pp'
 
+
+    def initialize(hash)
+        debug "init refacter, save Facter values"
+        @facts = Facter.to_hash
+        super
+    end
+
     # actually perform the check and (optional) reload
     def run
         Puppet.debug("reloading facter to see if facts changed")
@@ -32,7 +39,7 @@ END
     end
 
     def reload_facts( pattern, pconf, pnode )
-        old = get_matching_facts( loaded_facts(pnode), pattern, pnode )
+        old = get_matching_facts( @facts, pattern, pnode )
         new = get_matching_facts( refreshed_facts, pattern, pnode )
         diff = diff_hashes( old, new ) 
         return diff

--- a/lib/puppet/provider/refacter/ruby.rb
+++ b/lib/puppet/provider/refacter/ruby.rb
@@ -33,8 +33,8 @@ END
         end
         @refreshed = true
         Puppet.alert("reloading puppet to pick up new facts")
-        Puppet::Application.restart!
         pconf.run
+        Puppet::Application.stop!
         Puppet.alert("finished reloading puppet to pick up new facts")
     end
 

--- a/lib/puppet/provider/refacter/ruby.rb
+++ b/lib/puppet/provider/refacter/ruby.rb
@@ -1,79 +1,81 @@
+require 'puppet/configurer'
+require 'set'
+require 'pp'
+# rubocop: disable Metrics/MethodLength
+# rubocop: disable Metrics/LineLength
+# rubocop: disable Style/Semicolon
 
 Puppet::Type.type(:refacter).provide(:ruby) do
   desc <<-END
 
-    This provider handles rerunning facter to reload all the known facts
-    for the refacter type.
+  This provider handles rerunning facter to reload all the known facts
+  for the refacter type.
 
-END
-    require 'puppet/configurer'
-    require 'set'
-    require 'pp'
+  END
 
+  def initialize(hash)
+    debug 'init refacter, save Facter values'
+    @facts = Facter.to_hash
+    super
+  end
 
-    def initialize(hash)
-        debug "init refacter, save Facter values"
-        @facts = Facter.to_hash
-        super
+  # actually perform the check and (optional) reload
+  def run
+    Puppet.debug('reloading facter to see if facts changed')
+    pattern = resource[:pattern]
+    pnode = Puppet[:node_name_value]
+    pconf = Puppet::Configurer.new
+
+    fact_diff_hash = reload_facts(pattern, pconf, pnode)
+    if fact_diff_hash.empty?
+      Puppet.debug('facts stayed the same after reloading facter')
+      return
+    else
+      Puppet.notice('facts changed after reloading facter')
     end
+    @refreshed = true
+    Puppet.alert('reloading puppet to pick up new facts')
+    Puppet::Application.restart!
+    pconf.run
+    # Puppet::Application.stop!
+    Puppet.alert('finished reloading puppet to pick up new facts')
+    true
+  end
 
-    # actually perform the check and (optional) reload
-    def run
-        Puppet.debug("reloading facter to see if facts changed")
-        pattern = resource[:pattern]
-        pnode = Puppet[:node_name_value]
-        pconf = Puppet::Configurer.new()
+  def reload_facts(pattern, _pconf, pnode)
+    old = get_matching_facts(@facts, pattern, pnode)
+    new = get_matching_facts(refreshed_facts, pattern, pnode)
+    diff = diff_hashes(old, new)
+    diff
+  end
 
-        fact_diff_hash = reload_facts( pattern, pconf, pnode )
-        if fact_diff_hash.empty?
-            Puppet.debug("facts stayed the same after reloading facter")
-            return
-        else
-            Puppet.notice("facts changed after reloading facter")
-        end
-        @refreshed = true
-        Puppet.alert("reloading puppet to pick up new facts")
-        pconf.run
-        Puppet::Application.stop!
-        Puppet.alert("finished reloading puppet to pick up new facts")
+  def get_matching_facts(fact_hash, pattern, _pnode)
+    clean_facts = fact_hash.reject { |k, _v| !k.is_a?(String) || k[0..0] == '_' }
+    matched_facts = pattern ? clean_facts.reject { |k, _v| !pattern.match(k) } : clean_facts
+    matched_facts
+  end
+
+  # given two hashes, this returns a "diff hash" where only the keys and
+  # values that differ between the given hashes are listed. All values
+  # become two-element arrays where the first element is the value from
+  # the first hash and the second is the value from the second hash. If
+  # a key was missing from either hash its corresponding value will be
+  # nil. This isn't perfect, but will do for now. Speed wins.
+  def diff_hashes(h1, h2)
+    both_keys = Set[h1.keys] | h2.keys
+    diff_hash = both_keys.each_with_object({}) do |k, h|
+      h[k] = [h1[k], h2[k]] if h1[k] != h2[k]; h
     end
+    # pp h1, h2, diff_hash
+    diff_hash
+  end
 
-    def reload_facts( pattern, pconf, pnode )
-        old = get_matching_facts( @facts, pattern, pnode )
-        new = get_matching_facts( refreshed_facts, pattern, pnode )
-        diff = diff_hashes( old, new ) 
-        return diff
-    end
+  def loaded_facts(pnode)
+    Puppet::Node::Facts.indirection.find(pnode).values
+  end
 
-    def get_matching_facts( fact_hash, pattern, pnode )
-        clean_facts = fact_hash.reject { |k,v| ( ! k.is_a?( String ) ) or k[0..0] == "_" }
-        matched_facts = pattern ? clean_facts.reject { |k,v| ! pattern.match(k) } : clean_facts
-        return matched_facts
-    end
-
-    # given two hashes, this returns a "diff hash" where only the keys and
-    # values that differ between the given hashes are listed. All values
-    # become two-element arrays where the first element is the value from
-    # the first hash and the second is the value from the second hash. If
-    # a key was missing from either hash its corresponding value will be
-    # nil. This isn't perfect, but will do for now. Speed wins.
-    def diff_hashes ( h1, h2 )
-        both_keys = Set[ h1.keys ] | h2.keys
-        diff_hash = both_keys.inject({}) do |h,k|
-            h[k] = [ h1[k], h2[k] ] if h1[k] != h2[k]; h
-        end
-        #pp h1, h2, diff_hash
-        return diff_hash
-    end
-
-    def loaded_facts(pnode)
-      Puppet::Node::Facts.indirection.find( pnode ).values()
-    end
-
-    def refreshed_facts
-      Facter.clear
-      Facter.to_hash
-    end
+  def refreshed_facts
+    Facter.clear
+    Facter.to_hash
+  end
 end
-
-# vi: set ts=4 sw=4 et :

--- a/lib/puppet/provider/refacter/ruby.rb
+++ b/lib/puppet/provider/refacter/ruby.rb
@@ -32,15 +32,13 @@ END
     end
 
     def reload_facts( pattern, pconf, pnode )
-        old = get_matching_facts( pattern, pnode )
-        pconf.reload_facter()
-        new = get_matching_facts( pattern, pnode )
+        old = get_matching_facts( loaded_facts(pnode), pattern, pnode )
+        new = get_matching_facts( refreshed_facts, pattern, pnode )
         diff = diff_hashes( old, new ) 
         return diff
     end
 
-    def get_matching_facts( pattern, pnode )
-        fact_hash = Puppet::Node::Facts.find( pnode ).values()
+    def get_matching_facts( fact_hash, pattern, pnode )
         clean_facts = fact_hash.reject { |k,v| ( ! k.is_a?( String ) ) or k[0..0] == "_" }
         matched_facts = pattern ? clean_facts.reject { |k,v| ! pattern.match(k) } : clean_facts
         return matched_facts
@@ -59,6 +57,15 @@ END
         end
         #pp h1, h2, diff_hash
         return diff_hash
+    end
+
+    def loaded_facts(pnode)
+      Puppet::Node::Facts.indirection.find( pnode ).values()
+    end
+
+    def refreshed_facts
+      Facter.clear
+      Facter.to_hash
     end
 end
 

--- a/lib/puppet/type/refacter.rb
+++ b/lib/puppet/type/refacter.rb
@@ -1,7 +1,9 @@
+# rubocop: disable Metrics/LineLength
+# rubocop: disable Style/Semicolon
+# rubocop: disable Style/HashSyntax
 
-Puppet::Type.newtype( :refacter ) do
-
-    desc <<-EOT
+Puppet::Type.newtype(:refacter) do
+  desc <<-EOT
     Forces puppet to rerun facter to reload and refresh all facts, if any of
     the facts matching the given pattern changed.
 
@@ -32,96 +34,94 @@ Puppet::Type.newtype( :refacter ) do
         -> class { "automount::loopbackdisks": }
 EOT
 
-    require 'pp'
+  require 'pp'
 
-    ### TODO: make the refreshonly mechanism some sort of mixin?
+  ### TODO: make the refreshonly mechanism some sort of mixin?
 
-    ### Code below copied from the exec type to support the "refreshonly" mechanism
-    def self.newcheck(name, options = {}, &block)
-      @checks ||= {}
-      check = newparam(name, options, &block)
-      @checks[name] = check
-    end
-    def self.checks
-      @checks ||= {}
-      @checks.keys
-    end
-    def refresh
-      provider.run if self.check_all_attributes(true)
-    end
-    # Verify that we pass all of the checks.  The argument determines whether
-    # we skip the :refreshonly check, which is necessary because we now check
-    # within refresh
-    def check_all_attributes(refreshing = false)
-      self.class.checks.each do |check|
-        next if refreshing and check == :refreshonly
-        if @parameters.include?(check)
-          val = @parameters[check].value
-          val = [val] unless val.is_a? Array
-          # return false if any check returns false
-          val.each do |value|
-            return false unless @parameters[check].check(value)
-          end
-        end
+  ### Code below copied from the exec type to support the "refreshonly" mechanism
+  def self.newcheck(name, options = {}, &block)
+    @checks ||= {}
+    check = newparam(name, options, &block)
+    @checks[name] = check
+  end
+
+  def self.checks
+    @checks ||= {}
+    @checks.keys
+  end
+
+  def refresh
+    provider.run if check_all_attributes(true)
+  end
+
+  # Verify that we pass all of the checks.  The argument determines whether
+  # we skip the :refreshonly check, which is necessary because we now check
+  # within refresh
+  def check_all_attributes(refreshing = false)
+    self.class.checks.each do |check|
+      next if refreshing && check == :refreshonly
+      next unless @parameters.include?(check)
+      val = @parameters[check].value
+      val = [val] unless val.is_a? Array
+      # return false if any check returns false
+      val.each do |value|
+        return false unless @parameters[check].check(value)
       end
-      # return true if everything was true
-      true
     end
-    ### Code above copied from the exec type to support the "refreshonly" mechanism
+    # return true if everything was true
+    true
+  end
+  ### Code above copied from the exec type to support the "refreshonly" mechanism
 
-    newparam(:name, :namevar => true) do
-        desc 'An arbitrary name used as the identity of the resource.'
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:patterns) do
+    desc 'only reload if facts whose names match these patterns changed'
+    munge { |val| resource[:pattern] = val; nil }
+    validate do |_val|
+      raise ArgumentError,
+            "Can not use both the 'pattern' and 'patterns' attributes " \
+            'at the same time.' unless resource[:pattern].nil?
     end
+  end
 
-    newparam( :patterns ) do
-        desc "only reload if facts whose names match these patterns changed"
-        munge { |val| resource[:pattern] = val; nil }
-        validate do |val|
-            raise ArgumentError,
-                  "Can not use both the 'pattern' and 'patterns' attributes " +
-                  "at the same time." unless resource[:pattern].nil?
-        end
+  newparam(:pattern) do
+    desc 'only reload if facts whose names match this pattern changed'
+    defaultto :undef
+    validate do |val|
+      if resource[:patterns].nil? && val == :undef
+        raise ArgumentError, "Either 'pattern' or 'patterns' must be set."
+      end
     end
-
-    newparam( :pattern ) do
-        desc "only reload if facts whose names match this pattern changed"
-        defaultto :undef
-        validate do |val|
-            if resource[:patterns].nil? and val == :undef
-                raise ArgumentError, "Either 'pattern' or 'patterns' must be set."
-            end
-        end
-        munge do |val|
-            raise ArgumentError,
-                  "Can not use both the 'pattern' and 'patterns' attributes " +
-                  "at the same time." unless resource[:patterns].nil?
-            pats = val.is_a?( Array ) ? val : [ val ]
-            re = nil
-            begin
-                re = Regexp.new( pats.shift(), Regexp::EXTENDED )
-                re = re.union( pats ) unless pats.empty?
-            rescue => details
-                re = nil # make sure its nil
-            end
-            raise ArgumentError,
-                  "Could not compile one of the followine regexps: " +
-                  pats.pretty_inspect() if re.nil?
-            return re
-        end
+    munge do |val|
+      raise ArgumentError,
+            "Can not use both the 'pattern' and 'patterns' attributes " \
+            'at the same time.' unless resource[:patterns].nil?
+      pats = val.is_a?(Array) ? val : [val]
+      re = nil
+      begin
+        re = Regexp.new(pats.shift, Regexp::EXTENDED)
+        re = re.union(pats) unless pats.empty?
+      rescue => _details
+        re = nil # make sure its nil
+      end
+      raise ArgumentError,
+            'Could not compile one of the followine regexps: ' +
+            pats.pretty_inspect if re.nil?
+      return re
     end
+  end
 
-    newparam( :refreshonly ) do
-        desc "only reload if this resource recieves a notification"
-        newvalues :true, :false
-        defaultto :true
-        def check(value)
-            # check should always fail if this param is true.
-            # (this is what makes refreshonly work)
-            value == :true ? false : true
-        end
+  newparam(:refreshonly) do
+    desc 'only reload if this resource recieves a notification'
+    newvalues :true, :false
+    defaultto :true
+    def check(value)
+      # check should always fail if this param is true.
+      # (this is what makes refreshonly work)
+      value == :true ? false : true
     end
-
-
+  end
 end
-
-# vi: set ts=4 sw=4 et :

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,15 @@
+{
+  "name": "morpheu-refacter",
+  "version": "0.0.1",
+  "author": "Stephen R. Scaffidi",
+  "license": "MIT-style license that can be found in the LICENSE file",
+  "summary": "Puppet module to refresh facter and automatically reload on changes",
+  "source": "https://github.com/morpheu/puppet-refacter",
+  "project_page": "(https://github.com/morpheu/puppet-refacter)",
+  "issues_url": "https://github.com/morpheu/puppet-refacter/issues",
+  "tags": ["facter"],
+  "operatingsystem_support": [
+    {"operatingsystem": "Ubuntu",
+    "operatingsystemrelease": [ "14.04" ]}
+   ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,54 @@
 {
-  "name": "morpheu-refacter",
-  "version": "0.0.1",
-  "author": "Stephen R. Scaffidi",
+  "name": "hajee-refacter",
+  "version": "0.1.0",
+  "author": "Stephen R. Scaffidi, Bert Hajee, Paulo Sousa",
   "license": "MIT-style license that can be found in the LICENSE file",
   "summary": "Puppet module to refresh facter and automatically reload on changes",
-  "source": "https://github.com/morpheu/puppet-refacter",
-  "project_page": "(https://github.com/morpheu/puppet-refacter)",
-  "issues_url": "https://github.com/morpheu/puppet-refacter/issues",
+  "source": "https://github.com/hajee/puppet-refacter",
+  "project_page": "(https://github.com/hajee/puppet-refacter)",
+  "issues_url": "https://github.com/hajee/puppet-refacter/issues",
   "tags": ["facter"],
   "operatingsystem_support": [
-    {"operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [ "14.04" ]}
-   ]
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04"
+      ]
+    }
+  ]
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,16 +3,16 @@ require 'pathname'
 dir = Pathname.new(__FILE__).parent
 $LOAD_PATH.unshift(dir, dir + 'lib', dir + '../lib')
 
-require 'mocha'
 require 'puppet'
 require 'rspec'
+require 'rspec/mocks'
 
 RSpec.configure do |config|
-    config.mock_with :mocha
+  config.mock_with :rspec
 end
 
 # We need this because the RAL uses 'should' as a method.  This
 # allows us the same behaviour but with a different method name.
 class Object
-    alias :must :should
+  alias must should
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'pathname'
+dir = Pathname.new(__FILE__).parent
+$LOAD_PATH.unshift(dir, dir + 'lib', dir + '../lib')
+
+require 'mocha'
+require 'puppet'
+require 'rspec'
+
+RSpec.configure do |config|
+    config.mock_with :mocha
+end
+
+# We need this because the RAL uses 'should' as a method.  This
+# allows us the same behaviour but with a different method name.
+class Object
+    alias :must :should
+end

--- a/spec/unit/puppet/type/refacter_spec.rb
+++ b/spec/unit/puppet/type/refacter_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'tmpdir'
+
+describe Puppet::Type.type(:refacter) do
+
+  before do
+    Puppet::Util::Storage.stubs(:store)
+  end
+
+  context "change facter value for foo" do
+    before :each do
+      @tmpdir = Dir.mktmpdir("refacter_run")
+      Facter.add(:foo) {
+        if File.exists?(@tmpdir)
+          setcode  'bar'
+        else
+          setcode  'bleh'
+        end
+      }
+    end
+
+    after :each do
+      Facter.clear
+      Facter.clear_messages
+      begin
+        Dir.rmdir(@tmpdir)
+      rescue
+      end
+    end
+
+    it 'should return bar when change facter foo' do
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource(Puppet::Type.type(:file).new(:name => @tmpdir, :ensure => 'absent'))
+      catalog.apply
+      expect(Facter.value(:foo)).to eq('bar')
+    end
+
+    it 'should return bleh when change facter foo using refacter' do
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource(Puppet::Type.type(:file).new(:name => @tmpdir, :ensure => 'absent'))
+      catalog.add_resource(Puppet::Type.type(:refacter).new(:name => "foo", :pattern => "foo",:require => "File[#{@tmpdir}]"))
+      catalog.apply
+      expect(Facter.value(:foo)).to eq('bleh')
+    end
+  end
+end

--- a/spec/unit/puppet/type/refacter_spec.rb
+++ b/spec/unit/puppet/type/refacter_spec.rb
@@ -1,46 +1,79 @@
 require 'spec_helper'
-require 'tmpdir'
+# rubocop: disable Metrics/LineLength
+# rubocop: disable Style/HashSyntax
 
 describe Puppet::Type.type(:refacter) do
+  TEMPDIR = '/tmp/refacter_run'.freeze
+  TESTDIR = '/tmp/refacter_test'.freeze
 
   before do
-    Puppet::Util::Storage.stubs(:store)
+    allow(Puppet::Util::Storage).to receive(:store)
+    # Uncomment next two lines if you want to see the puppet debug
+    # Puppet::Util::Log.level = :debug
+    # Puppet::Util::Log.newdestination(:console)
+    allow(Puppet.settings).to receive(:[]).and_wrap_original do |m, *args|
+      item = args.first
+      case item
+      when /.*dir/
+        `pwd`
+      when :classfile
+        './.tmp/classes.txt'
+      when :resourcefile
+        './.tmp/resources.txt'
+      when :transactionstorefile
+        './.tmp/transactionstore.yaml'
+      when :lastrunfile
+        './.tmp/last_run_summary.yaml'
+      else
+        m.call(*args)
+      end
+    end
   end
 
-  context "change facter value for foo" do
+  context 'changing facter value for uptime_seconds' do
     before :each do
-      @tmpdir = Dir.mktmpdir("refacter_run")
-      Facter.add(:foo) {
-        if File.exists?(@tmpdir)
-          setcode  'bar'
-        else
-          setcode  'bleh'
-        end
-      }
+      Dir.mkdir(TEMPDIR)
+      Dir.rmdir(TESTDIR) if File.exist?(TESTDIR)
     end
 
     after :each do
       Facter.clear
       Facter.clear_messages
-      begin
-        Dir.rmdir(@tmpdir)
-      rescue
+      Dir.rmdir(TEMPDIR) if File.exist?(TEMPDIR)
+      Dir.rmdir(TESTDIR) if File.exist?(TESTDIR)
+    end
+
+    context 'no refacter type loaded' do
+      it 'should return same fact value before and after puppet run' do
+        current_update = Facter.value('uptime_seconds')
+        sleep(1) # Make sure we have at least one second difference
+        catalog = Puppet::Resource::Catalog.new
+        catalog.add_resource(Puppet::Type.type(:file).new(:name => TEMPDIR, :ensure => 'absent', :force => true))
+        catalog.add_resource(Puppet::Type.type(:refacter).new(:name => 'foo', :pattern => 'timezone', :require => "File[#{TEMPDIR}]"))
+        catalog.apply
+        expect(Facter.value('uptime_seconds')).to eq(current_update)
       end
     end
 
-    it 'should return bar when change facter foo' do
-      catalog = Puppet::Resource::Catalog.new
-      catalog.add_resource(Puppet::Type.type(:file).new(:name => @tmpdir, :ensure => 'absent'))
-      catalog.apply
-      expect(Facter.value(:foo)).to eq('bar')
-    end
+    context 'refacter class refeshed' do
+      it 'should return different fact value before and after puppet run' do
+        current_update = Facter.value('uptime_seconds')
+        sleep(1) # Make sure we have at least one second difference
+        catalog = Puppet::Resource::Catalog.new
+        catalog.add_resource(Puppet::Type.type(:file).new(:name => TEMPDIR, :ensure => 'absent', :force => true))
+        catalog.add_resource(Puppet::Type.type(:refacter).new(:name => 'foo', :pattern => 'uptime_seconds', :subscribe => "File[#{TEMPDIR}]"))
+        catalog.apply
+        expect(Facter.value('uptime_seconds')).not_to eq(current_update)
+      end
 
-    it 'should return bleh when change facter foo using refacter' do
-      catalog = Puppet::Resource::Catalog.new
-      catalog.add_resource(Puppet::Type.type(:file).new(:name => @tmpdir, :ensure => 'absent'))
-      catalog.add_resource(Puppet::Type.type(:refacter).new(:name => "foo", :pattern => "foo",:require => "File[#{@tmpdir}]"))
-      catalog.apply
-      expect(Facter.value(:foo)).to eq('bleh')
+      it 'should run the next resource in the catalog after refacter' do
+        catalog = Puppet::Resource::Catalog.new
+        catalog.add_resource(Puppet::Type.type(:file).new(:name => TEMPDIR, :ensure => 'absent', :force => true))
+        catalog.add_resource(Puppet::Type.type(:refacter).new(:name => 'foo', :pattern => 'uptime_seconds', :subscribe => "File[#{TEMPDIR}]"))
+        catalog.add_resource(Puppet::Type.type(:file).new(:name => TESTDIR, :ensure => 'directory', :require => 'Refacter[foo]'))
+        catalog.apply
+        expect(File.exist?(TESTDIR)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
It now works without syntax errors. Still having problems with my original case.

``` puppet
  network_config { 'eth2':
    ensure    => 'present',
    family    => 'inet',
    method    => 'static',
    onboot    => 'true',
    hotplug   => 'true',
    ipaddress => $private_ipaddress,
    netmask   => '255.255.255.0',
  } ~>

  service{'network':
    ensure  => 'running',
  } ~>

  refacter{'define_eth2_facts':
    patterns => [ "network" ],
  }
```

Somehow the new network facts for eth2 are not picked up.Any help or suggestions are welcome!
